### PR TITLE
BUILD-7396: Update CODEOWNERS for platform-eng-ex-squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @sonarsource/platform-devinfra-squad
+* @sonarsource/platform-eng-ex-squad
 
 # No review needed for documentation
 *.md


### PR DESCRIPTION
This PR updates the CODEOWNERS file to replace the team @SonarSource/platform-devinfra-squad with @SonarSource/platform-eng-ex-squad.